### PR TITLE
Use Brotli quality 4 for streaming compression as well

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Use Brotli quality 4 for streaming responses as well, which is ~100 times faster than the default quality, 11.
+
+  `PR #18 <https://github.com/adamchainz/django-http-compression/pull/18>`__.
+
 1.1.0 (2025-10-15)
 ------------------
 

--- a/src/django_http_compression/middleware.py
+++ b/src/django_http_compression/middleware.py
@@ -46,6 +46,12 @@ except ImportError:  # pragma: no cover
     HAVE_BROTLI = False
 
 
+# Copy CloudFlare’s default quality setting, to balance
+# speed versus savings.
+# https://blog.cloudflare.com/results-experimenting-brotli/
+BROTLI_QUALITY = 4
+
+
 class HttpCompressionMiddleware:
     """
     Compress content with the best-supported encoding that the client accepts.
@@ -164,10 +170,7 @@ class HttpCompressionMiddleware:
             elif coding == "br":
                 compressed_content = brotli_compress(
                     response.content,
-                    # Copy CloudFlare’s default quality setting, to balance
-                    # speed versus savings.
-                    # https://blog.cloudflare.com/results-experimenting-brotli/
-                    quality=4,
+                    quality=BROTLI_QUALITY,
                 )
             elif coding == "zstd":
                 compressed_content = zstd_compress(
@@ -312,7 +315,7 @@ def brotli_compress_sequence(sequence: Iterator[bytes]) -> Generator[bytes]:
     # Output headers
     yield b""
 
-    compressor = BrotliCompressor()
+    compressor = BrotliCompressor(quality=BROTLI_QUALITY)
     for item in sequence:
         data = compressor.process(item)
         data += compressor.flush()


### PR DESCRIPTION
The middleware previously used the default quality for streaming responses, which is particularly slow (like 100 times slower). This PR uses the same quality setting as for non-streaming responses, 4, as used by CloudFlare.