### PR TITLE
Expand Heal the Breach mitigation to all encodings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+* Expand the **Heal the Breach mitigation** to all encodings, rather than just Gzip (as previously copied from Django).
+  This is done by setting an ``x-noise`` header on all compressed responses, which contains a random token of between 0 and 99 bytes, Base64-encoded.
+
+  Thanks to Andreas Pelme for the suggested implementation in `Issue #14 <https://github.com/adamchainz/django-http-compression/issues/14>`__, and to Jacob Walls and Jake Howard of the Django security team for their input.
+
 1.3.0 (2026-04-08)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -123,9 +123,10 @@ The middleware skips compression if any of the following are true:
 
 If the response has an ``etag`` header, the ``etag`` is made weak to comply with `RFC 9110 Section 8.8.1 <https://datatracker.ietf.org/doc/html/rfc9110.html#section-8.8.1>`__.
 
-For the Gzip coding, the middleware mitigates some attacks using the *Heal the Breach (HTB)* technique, as used in Django’s ``GzipMiddleware``.
-This fix adds a small number of random bytes to each response.
-To change the maximum number of random bytes added to responses, subclass the middleware and change the ``gzip_max_random_bytes`` attribute appropriately (default 100).
+The middleware mitigates some attacks using the `Heal the Breach (HTB) technique <https://ieeexplore.ieee.org/document/9754554>`__, like Django’s ``GzipMiddleware`` does.
+This technique adds some random padding to responses: an ``x-noise`` header with a random token containing between 0 and 99 bytes long, Base64-encoded.
+This padding makes it much harder for attackers to infer the contents of the response by measuring its compressed size while modifying some input, for example by trying to guess an embedded session token character-by-character.
+To change the maximum number of random bytes added to responses, subclass the middleware and set the ``max_random_bytes`` attribute.
 
 History
 -------

--- a/src/django_http_compression/middleware.py
+++ b/src/django_http_compression/middleware.py
@@ -12,6 +12,7 @@ from collections.abc import (
 )
 from functools import lru_cache, partial
 from gzip import GzipFile
+from secrets import randbelow, token_urlsafe
 from types import MappingProxyType
 from typing import Literal, cast
 
@@ -19,10 +20,7 @@ from asgiref.sync import iscoroutinefunction, markcoroutinefunction
 from django.http import HttpRequest, HttpResponse, StreamingHttpResponse
 from django.http.response import HttpResponseBase
 from django.utils.cache import patch_vary_headers
-from django.utils.text import (  # type: ignore [attr-defined]
-    StreamingBuffer,
-    _get_random_filename,
-)
+from django.utils.text import StreamingBuffer
 from django.utils.text import compress_string as gzip_compress
 from typing_extensions import assert_never
 
@@ -55,7 +53,7 @@ class HttpCompressionMiddleware:
     on the Accept-Encoding header.
     """
 
-    gzip_max_random_bytes = 100
+    max_random_bytes = 99
 
     # Seeded from Caddy’s default list of compressible content types
     # https://caddyserver.com/docs/caddyfile/directives/encode
@@ -169,7 +167,6 @@ class HttpCompressionMiddleware:
                     compressed_wrapper = partial(
                         gzip_compress_sequence_async,
                         streaming_content,
-                        max_random_bytes=self.gzip_max_random_bytes,
                     )
 
                 elif coding == "br":
@@ -189,8 +186,7 @@ class HttpCompressionMiddleware:
             else:
                 if coding == "gzip":
                     response.streaming_content = gzip_compress_sequence(
-                        response.streaming_content,  # type: ignore [arg-type]
-                        max_random_bytes=self.gzip_max_random_bytes,
+                        response.streaming_content  # type: ignore [arg-type]
                     )
                 elif coding == "br":
                     response.streaming_content = brotli_compress_sequence(
@@ -209,10 +205,7 @@ class HttpCompressionMiddleware:
             response = cast(HttpResponse, response)
             # Return the compressed content only if it's actually shorter.
             if coding == "gzip":
-                compressed_content = gzip_compress(
-                    response.content,
-                    max_random_bytes=self.gzip_max_random_bytes,
-                )
+                compressed_content = gzip_compress(response.content, max_random_bytes=0)
             elif coding == "br":
                 compressed_content = brotli_compress(
                     response.content,
@@ -231,6 +224,12 @@ class HttpCompressionMiddleware:
                 return
             response.content = compressed_content
             response.headers["content-length"] = str(len(response.content))
+
+        # BREACH mitigation: add a padding header of random length
+        if self.max_random_bytes:
+            response.headers["x-noise"] = token_urlsafe(
+                randbelow(self.max_random_bytes + 1)
+            )
 
         # If there is a strong ETag, make it weak to fulfill the requirements
         # of RFC 9110 Section 8.8.1 while also allowing conditional request
@@ -312,17 +311,14 @@ def _parse_part(
     return None
 
 
-def gzip_compress_sequence(
-    sequence: Iterator[bytes], *, max_random_bytes: int
-) -> Generator[bytes]:
+def gzip_compress_sequence(sequence: Iterator[bytes]) -> Generator[bytes]:
     """
     Copy of Django’s compress_sequence() but with streaming response flushing
-    bug fixed.
+    bug fixed and random bytes feature removed in favour of x-pad header.
     """
     buf = StreamingBuffer()
-    filename = _get_random_filename(max_random_bytes) if max_random_bytes else None
     with GzipFile(
-        filename=filename, mode="wb", compresslevel=6, fileobj=buf, mtime=0
+        filename=None, mode="wb", compresslevel=6, fileobj=buf, mtime=0
     ) as zfile:
         # Output headers...
         yield b""  # Optimization
@@ -336,15 +332,14 @@ def gzip_compress_sequence(
 
 
 async def gzip_compress_sequence_async(
-    sequence: AsyncIterator[bytes], *, max_random_bytes: int
+    sequence: AsyncIterator[bytes],
 ) -> AsyncGenerator[bytes]:
     """
     Fixed version of Django's gzip_wrapper().
     """
     buf = StreamingBuffer()
-    filename = _get_random_filename(max_random_bytes) if max_random_bytes else None
     with GzipFile(
-        filename=filename, mode="wb", compresslevel=6, fileobj=buf, mtime=0
+        filename=None, mode="wb", compresslevel=6, fileobj=buf, mtime=0
     ) as zfile:
         # Output headers...
         yield b""  # Optimization

--- a/src/django_http_compression/middleware.py
+++ b/src/django_http_compression/middleware.py
@@ -314,7 +314,7 @@ def _parse_part(
 def gzip_compress_sequence(sequence: Iterator[bytes]) -> Generator[bytes]:
     """
     Copy of Django’s compress_sequence() but with streaming response flushing
-    bug fixed and random bytes feature removed in favour of x-pad header.
+    bug fixed and random bytes feature removed in favour of x-noise header.
     """
     buf = StreamingBuffer()
     with GzipFile(
@@ -335,7 +335,8 @@ async def gzip_compress_sequence_async(
     sequence: AsyncIterator[bytes],
 ) -> AsyncGenerator[bytes]:
     """
-    Fixed version of Django's gzip_wrapper().
+    Fixed version of Django's gzip_wrapper(), and with random bytes feature
+    removed in favour of x-noise header.
     """
     buf = StreamingBuffer()
     with GzipFile(

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -9,6 +9,7 @@ from gzip import decompress as gzip_decompress
 from http import HTTPStatus
 from textwrap import dedent
 from typing import cast
+from unittest import mock
 
 import django
 import pytest
@@ -639,6 +640,15 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert 0 <= len(response.headers["x-noise"]) <= 132
         assert response.headers["etag"] == 'W/"12345"'
         assert response.content.startswith(b"\x1f\x8b\x08")
+
+    def test_random_bytes_disabled(self):
+        with mock.patch.object(HttpCompressionMiddleware, "max_random_bytes", 0):
+            response = self.client.get("/", headers={"accept-encoding": "gzip"})
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.headers["content-encoding"] == "gzip"
+        assert response.headers["vary"] == "accept-encoding"
+        assert "x-noise" not in response.headers
 
     @parametrize(
         "content_type,expected",

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -61,6 +61,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "gzip"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         assert response.content.startswith(b"\x1f\x8b\x08")
         decompressed = gzip_decompress(response.content)
         assert decompressed.decode() == basic_html
@@ -71,6 +72,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "br"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         assert response.content.startswith(b"\x1b]\x01\x00")
         decompressed = brotli_decompress(response.content)
         assert decompressed.decode() == basic_html
@@ -81,6 +83,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "zstd"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         assert response.content.startswith(b"(\xb5/\xfd")
         decompressed = zstd_decompress(response.content)
         assert decompressed.decode() == basic_html
@@ -111,6 +114,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "gzip"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
 
         decompressor = zlib.decompressobj(zlib.MAX_WBITS | 16)  # gzip decoding
         content = b""
@@ -141,6 +145,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "br"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
 
         streaming_content = cast(Iterator[bytes], response.streaming_content)
         decompressor = BrotliDecompressor()
@@ -172,6 +177,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "zstd"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
 
         streaming_content = cast(Iterator[bytes], response.streaming_content)
         decompressor = ZstdDecompressor()
@@ -213,6 +219,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "gzip"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         content = response.getvalue()
         assert content.startswith(b"\x1f\x8b\x08")
         decompressed = gzip.decompress(content)
@@ -226,6 +233,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "br"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         content = response.getvalue()
         assert content == b";"
         decompressed = brotli_decompress(content)
@@ -239,6 +247,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "zstd"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         content = response.getvalue()
         assert content.startswith(b"(\xb5/\xfd")
         decompressed = zstd_decompress(content)
@@ -261,6 +270,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "gzip"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         content = response.getvalue()
         assert content.startswith(b"\x1f\x8b\x08")
         decompressed = gzip.decompress(content)
@@ -274,6 +284,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "br"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         content = response.getvalue()
         assert content == b"k\x00\x03"
         decompressed = brotli_decompress(content)
@@ -287,6 +298,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "zstd"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         content = response.getvalue()
         assert content.startswith(b"(\xb5/\xfd")
         decompressed = zstd_decompress(content)
@@ -308,6 +320,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "gzip"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         assert response.content.startswith(b"\x1f\x8b\x08")
         decompressed = gzip_decompress(response.content)
         assert decompressed.decode() == basic_html
@@ -320,6 +333,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "br"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         assert response.content.startswith(b"\x1b]\x01\x00")
         decompressed = brotli_decompress(response.content)
         assert decompressed.decode() == basic_html
@@ -332,6 +346,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "zstd"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         assert response.content.startswith(b"(\xb5/\xfd")
         decompressed = zstd_decompress(response.content)
         assert decompressed.decode() == basic_html
@@ -364,6 +379,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "gzip"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
 
         decompressor = zlib.decompressobj(zlib.MAX_WBITS | 16)  # gzip decoding
         content = b""
@@ -396,6 +412,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "br"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
 
         streaming_content = cast(AsyncIterator[bytes], response.streaming_content)
         decompressor = BrotliDecompressor()
@@ -429,6 +446,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "zstd"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
 
         streaming_content = cast(AsyncIterator[bytes], response.streaming_content)
         decompressor = ZstdDecompressor()
@@ -481,6 +499,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "gzip"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         streaming_content = cast(AsyncIterator[bytes], response.streaming_content)
         content = b""
         async for chunk in streaming_content:
@@ -498,6 +517,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "br"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         streaming_content = cast(AsyncIterator[bytes], response.streaming_content)
         content = b""
         async for chunk in streaming_content:
@@ -515,6 +535,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "zstd"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         streaming_content = cast(AsyncIterator[bytes], response.streaming_content)
         content = b""
         async for chunk in streaming_content:
@@ -546,6 +567,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "gzip"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         streaming_content = cast(AsyncIterator[bytes], response.streaming_content)
         content = b""
         async for chunk in streaming_content:
@@ -563,6 +585,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "br"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         streaming_content = cast(AsyncIterator[bytes], response.streaming_content)
         content = b""
         async for chunk in streaming_content:
@@ -580,6 +603,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "zstd"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         streaming_content = cast(AsyncIterator[bytes], response.streaming_content)
         content = b""
         async for chunk in streaming_content:
@@ -612,6 +636,7 @@ class HttpCompressionMiddlewareTests(ParametrizedTestCase, SimpleTestCase):
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-encoding"] == "gzip"
         assert response.headers["vary"] == "accept-encoding"
+        assert 0 <= len(response.headers["x-noise"]) <= 132
         assert response.headers["etag"] == 'W/"12345"'
         assert response.content.startswith(b"\x1f\x8b\x08")
 


### PR DESCRIPTION
Fixes #14. I went with @pelme’s suggestion to add an ``x-noise`` header to all responses.